### PR TITLE
Update command line scripts for Blender 4.0

### DIFF
--- a/example_model_config.json
+++ b/example_model_config.json
@@ -20,8 +20,8 @@
     "Name_plate_text_size": 18
   },
   "stl_keywords": {
-    "axis_forward": "Z",
-    "axis_up": "-Y"
+    "forward_axis": "Z",
+    "up_axis": "NEGATIVE_Y"
   },
   "output_path": "/Users/coleman/Desktop",
   "output_name": "M51_i"

--- a/install_all_addons.py
+++ b/install_all_addons.py
@@ -6,11 +6,12 @@ current_dir = os.getcwd()
 
 # install and activate `emboss plane`
 tu_plugin_filepath = os.path.join(current_dir, 'tactile_universe_plugin.zip')
-bpy.ops.preferences.addon_install(filepath=tu_plugin_filepath)
-bpy.ops.preferences.addon_enable(module='tactile_universe_plugin')
-
-# enable import images as plane
-bpy.ops.preferences.addon_enable(module='io_import_images_as_planes')
+bpy.ops.extensions.package_install_files(
+    filepath=tu_plugin_filepath,
+    repo='user_default',
+    overwrite=True,
+    enable_on_install=True
+)
 
 # save user preferences
 bpy.ops.wm.save_userpref()

--- a/make_holder.py
+++ b/make_holder.py
@@ -33,18 +33,18 @@ base_path = os.path.join(
 )
 
 stl_base_file_path = '{0}_base.stl'.format(base_path)
-bpy.ops.export_mesh.stl(
+bpy.ops.wm.stl_export(
     filepath=stl_base_file_path,
     check_existing=False,
-    use_selection=True
+    export_selected_objects=True
 )
 
 bpy.ops.object.select_all(action='INVERT')
 stl_lid_file_path = '{0}_lid.stl'.format(base_path)
-bpy.ops.export_mesh.stl(
+bpy.ops.wm.stl_export(
     filepath=stl_lid_file_path,
     check_existing=False,
-    use_selection=True
+    export_selected_objects=True
 )
 
 bpy.ops.file.pack_all()

--- a/make_model.py
+++ b/make_model.py
@@ -35,7 +35,7 @@ if input_dir == '':
     input_dir = os.getcwd()
 
 # import image as plane
-bpy.ops.import_image.to_plane(
+bpy.ops.image.import_as_mesh_planes(
     files=[{'name': input_name}],
     directory=input_dir,
     height=config['plane_height'],
@@ -71,7 +71,8 @@ override = {
 
 name = bpy.context.active_object.name
 bpy.ops.object.editmode_toggle()
-bpy.ops.object.emboss_plane(override, **config['emboss_plane_keywords'])
+with bpy.context.temp_override(**override):
+    bpy.ops.object.emboss_plane(**config['emboss_plane_keywords'])
 bpy.ops.object.editmode_toggle()
 
 base_path = os.path.join(
@@ -87,7 +88,7 @@ bpy.ops.wm.save_mainfile(
 )
 
 stl_file_path = '{0}.stl'.format(base_path)
-bpy.ops.export_mesh.stl(
+bpy.ops.wm.stl_export(
     filepath=stl_file_path,
     check_existing=False,
     **config['stl_keywords']


### PR DESCRIPTION
All the command line scripts have been updated to work with Blender 4.0 and up (tested on 4.3.2).  For the most part only function and keyword names needed updating.